### PR TITLE
Add photo albums + update photo related components

### DIFF
--- a/routes/photos/(_components)/album.tsx
+++ b/routes/photos/(_components)/album.tsx
@@ -21,7 +21,7 @@ export const Album = ({
 	return (
 		<a
 			href={`/photos/${slug}`}
-			class="max-w-sm mx-auto relative rounded-lg hover:shadow-lg border border-transparent hover:border-stone-300 dark:hover:border-stone-700"
+			class="max-w-sm mx-auto relative rounded-lg hover:shadow-lg border-2 border-transparent hover:border-stone-400 dark:hover:border-stone-600"
 		>
 			<picture class="max-w-full h-auto object-cover rounded-lg">
 				{/* AVIF format */}
@@ -66,7 +66,7 @@ export const Album = ({
 
 				{/* Default JPEG format (fallback) */}
 				<img
-					class="h-auto max-w-full rounded-t-lg object-cover rounded-lg"
+					class="h-auto max-w-full rounded-lg object-cover"
 					src={getImagorUrl(
 						`400x400/filters:format(avif):quality(80)/${imageCover}`,
 					)}

--- a/routes/photos/(_components)/album.tsx
+++ b/routes/photos/(_components)/album.tsx
@@ -19,74 +19,76 @@ export const Album = ({
 	const imageCover = photos[Math.floor(Math.random() * photos.length)].src;
 
 	return (
-		<div class="max-w-sm rounded-lg hover:shadow-lg transition-shadow duration-200 bg-stone-200 dark:bg-stone-700">
-			<a href={`/photos/${slug}`}>
-				<picture>
-					{/* AVIF format */}
-					<source
-						type="image/avif"
-						media="(max-width: 639px)"
-						srcSet={getImagorUrl(
-							`300x200/filters:format(avif):quality(80)/${imageCover}`,
-						)}
-						width={300}
-						height={200}
-					/>
-					<source
-						type="image/avif"
-						media="(min-width: 640px)"
-						srcSet={getImagorUrl(
-							`390x260/filters:format(avif):quality(80)/${imageCover}`,
-						)}
-						width={390}
-						height={260}
-					/>
-
-					{/* WEBP format */}
-					<source
-						type="image/webp"
-						media="(max-width: 639px)"
-						srcSet={getImagorUrl(
-							`300x200/filters:format(webp):quality(80)/${imageCover}`,
-						)}
-						width={300}
-						height={200}
-					/>
-					<source
-						type="image/webp"
-						media="(min-width: 640px)"
-						srcSet={getImagorUrl(
-							`390x260/filters:format(webp):quality(80)/${imageCover}`,
-						)}
-						width={390}
-						height={260}
-					/>
-
-					{/* Default JPEG format (fallback) */}
-					<img
-						class="h-auto max-w-full rounded-t-lg"
-						src={getImagorUrl(
-							`390x260/filters:format(avif):quality(80)/${imageCover}`,
-						)}
-						width={390}
-						height={260}
-						alt={`Cover photo for the album ${name}`}
-					/>
-				</picture>
-				<div class="p-2">
-					<h4 class="text-xl tracking-tight text-stone-900 dark:text-stone-100">
-						{name}
-					</h4>
-					{dates && (
-						<p class="font-normal text-stone-700 dark:text-stone-300">
-							{dates}
-						</p>
+		<a
+			href={`/photos/${slug}`}
+			class="max-w-sm mx-auto relative rounded-lg hover:shadow-lg border border-transparent hover:border-stone-300 dark:hover:border-stone-700"
+		>
+			<picture class="max-w-full h-auto object-cover rounded-lg">
+				{/* AVIF format */}
+				<source
+					type="image/avif"
+					media="(max-width: 639px)"
+					srcSet={getImagorUrl(
+						`300x300/filters:format(avif):quality(80)/${imageCover}`,
 					)}
-					<p class="font-normal text-stone-700 dark:text-stone-300">
-						{photoCount} photos
+					width={300}
+					height={200}
+				/>
+				<source
+					type="image/avif"
+					media="(min-width: 640px)"
+					srcSet={getImagorUrl(
+						`400x400/filters:format(avif):quality(80)/${imageCover}`,
+					)}
+					width={390}
+					height={260}
+				/>
+
+				{/* WEBP format */}
+				<source
+					type="image/webp"
+					media="(max-width: 639px)"
+					srcSet={getImagorUrl(
+						`300x300/filters:format(webp):quality(80)/${imageCover}`,
+					)}
+					width={300}
+					height={200}
+				/>
+				<source
+					type="image/webp"
+					media="(min-width: 640px)"
+					srcSet={getImagorUrl(
+						`400x400/filters:format(webp):quality(80)/${imageCover}`,
+					)}
+					width={390}
+					height={260}
+				/>
+
+				{/* Default JPEG format (fallback) */}
+				<img
+					class="h-auto max-w-full rounded-t-lg object-cover rounded-lg"
+					src={getImagorUrl(
+						`400x400/filters:format(avif):quality(80)/${imageCover}`,
+					)}
+					width={390}
+					height={260}
+					alt={`Cover photo for the album ${name}`}
+				/>
+			</picture>
+
+			<div class="absolute bottom-0 left-0 right-0 h-20 bg-stone-50/50 dark:bg-stone-950/50 backdrop-blur text-white p-2 rounded-b-lg">
+				<h4 class="text-l tracking-tight text-stone-900 dark:text-stone-100">
+					{name}
+				</h4>
+				{dates && (
+					<p class="text-sm text-stone-700 dark:text-stone-300">
+						{dates}
 					</p>
-				</div>
-			</a>
-		</div>
+				)}
+				<p class="text-sm text-stone-700 dark:text-stone-300">
+					{photoCount} photos
+				</p>
+			</div>
+		</a>
 	);
 };

--- a/routes/photos/(_components)/license.tsx
+++ b/routes/photos/(_components)/license.tsx
@@ -6,21 +6,57 @@
  * @returns {JSX.Element} The rendered License component.
  */
 export const License = (
-	{ year = new Date().getUTCFullYear().toString() }: { year?: string },
+	{
+		year = new Date().getUTCFullYear().toString(),
+		isPhoto = false,
+		noLicense = false,
+	}: {
+		year?: string;
+		isPhoto?: boolean;
+		noLicense?: boolean;
+	},
 ) => {
 	return (
 		<div class="text-xs text-start text-stone-600 dark:text-stone-400 mt-6">
-			{/* @ts-ignore -- cc licence */}
-			<span xmlns:cc="http://creativecommons.org/ns#">
-				&copy; Mahesh Makani {year}. All photos licensed under{" "}
-				<a
-					class="text-xs underline hover:text-stone-700 dark:hover:text-stone-300 inline"
-					href="https://creativecommons.org/licenses/by-nc-sa/4.0/"
-					target="_blank"
-				>
-					CC BY-SA 4.0
-				</a>. Contact me for high-res versions or commercial use.
-			</span>
+			{isPhoto
+				? (
+					// @ts-ignore -- cc license tag
+					<span xmlns:cc="http://creativecommons.org/ns#">
+						&copy; Mahesh Makani {year}. {noLicense
+							? (
+								<b>
+									This photo is NOT licensed for any use.
+								</b>
+							)
+							: (
+								<>
+									This photo is licensed under{" "}
+									<a
+										class="text-xs underline hover:text-stone-700 dark:hover:text-stone-300 inline"
+										href="https://creativecommons.org/licenses/by-nc-sa/4.0/"
+										target="_blank"
+									>
+										CC BY-SA 4.0
+									</a>. Contact me for high-res versions or commercial use.
+								</>
+							)}
+					</span>
+				)
+				: (
+					// @ts-ignore -- cc license tag
+					<span xmlns:cc="http://creativecommons.org/ns#">
+						&copy; Mahesh Makani {year}. Photos licensed under{" "}
+						<a
+							class="text-xs underline hover:text-stone-700 dark:hover:text-stone-300 inline"
+							href="https://creativecommons.org/licenses/by-nc-sa/4.0/"
+							target="_blank"
+						>
+							CC BY-SA 4.0
+						</a>{" "}
+						unless otherwise stated on the photo page. Contact me for high-res
+						versions or commercial use.
+					</span>
+				)}
 		</div>
 	);
 };

--- a/routes/photos/(_utils)/albums.ts
+++ b/routes/photos/(_utils)/albums.ts
@@ -8,11 +8,13 @@ import { getImagorUrl } from "@/utils/imagor.ts";
  * @property {string} src - Name of the photo file as stored in s3.
  * @property {string} slug - URL slug of the photo.
  * @property {string} [timezone] - Timezone of the photo, if known, otherwise defaults to `Europe/London`. Based on https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+ * @property {boolean} [noLicense] - If true, the photo is not licensed under CC BY-NC-SA 4.0.
  */
 export type Photo = {
 	src: string;
 	slug: string;
 	timezone?: "Europe/London" | "Asia/Tokyo";
+	noLicense?: boolean;
 };
 
 /**

--- a/routes/photos/(_utils)/albums.ts
+++ b/routes/photos/(_utils)/albums.ts
@@ -183,6 +183,77 @@ const IzuPeninsula: Album = {
 	],
 };
 
+const Kyoto: Album = {
+	name: "Kyoto Wanders",
+	slug: "kyoto-wanders",
+	dates: "April 2024",
+	copyrightYear: "2024",
+	photos: [
+		{
+			src: "20240414-3_87A0799-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "kyoto-mossy-inari",
+		},
+		{
+			src: "20240414-3_87A0862-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "kyoto-fushimi-inari-portrait",
+			noLicense: true,
+		},
+		{
+			src: "20240413-2_87A0394-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "kyoto-temple-buddhas",
+		},
+		{
+			src: "20240414-3_87A0819-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "kyoto-cat-2",
+		},
+
+		{
+			src: "20240413-2_87A0583-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "kyoto-mt-hiei-view",
+		},
+		{
+			src: "20240413-2_87A0590-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "kyoto-cat-1",
+		},
+		{
+			src: "20240413-2_87A0599-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "kyoto-rail-infra",
+		},
+		{
+			src: "20240414-3_87A0903-Pano.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "kyoto-city-panorama",
+		},
+		{
+			src: "20240415-3_87A1002-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "kyoto-philosopher-path",
+		},
+		{
+			src: "20240415-3_87A1037-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "kyoto-single-train",
+		},
+		{
+			src: "20240413-2_87A0388-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "kyoto-temple-path",
+		},
+		{
+			src: "20240413-2_87A0658-Pano.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "kyoto-kiyomizu-city-panorama",
+		},
+	],
+};
+
 /**
  * @name ALBUMS
  * @description Array of all albums to display, order matters.
@@ -192,6 +263,7 @@ const IzuPeninsula: Album = {
 export const ALBUMS: Album[] = [
 	IzuPeninsula,
 	TokyoSkytreeVistas,
+	Kyoto,
 ];
 
 /**

--- a/routes/photos/(_utils)/albums.ts
+++ b/routes/photos/(_utils)/albums.ts
@@ -312,6 +312,80 @@ const TokyoDay: Album = {
 	],
 };
 
+const TokyoNight: Album = {
+	name: "Tokyo Night City",
+	slug: "tokyo-night-city",
+	dates: "April 2024",
+	copyrightYear: "2024",
+	photos: [
+		{
+			src: "20240419-3_87A1598-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-night-silhouette",
+		},
+		{
+			src: "20240419-3_87A1600-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-night-virtual-construction",
+		},
+		{
+			src: "20240409-1_87A0255-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-night-tower",
+		},
+		{
+			src: "20240417-3_87A1090-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-night-vending-train",
+		},
+		{
+			src: "20240417-3_87A1103-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-night-wall-art",
+		},
+		{
+			src: "20240417-3_87A1120-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-night-lone-walker",
+		},
+		{
+			src: "20240417-3_87A1168-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-night-rail-apartments",
+		},
+		{
+			src: "20240417-3_87A1179-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-night-shinjuku-station",
+		},
+		{
+			src: "20240417-3_87A1184-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-night-salaryman",
+		},
+		{
+			src: "20240419-3_87A1602-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-night-lawson",
+		},
+		{
+			src: "20240426-3_87A3102-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-night-toll-gate",
+		},
+		{
+			src: "20240426-3_87A3117-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-night-apartment-lights",
+		},
+		{
+			src: "20240427-3_87A3201-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-night-akihabara-station",
+		},
+	],
+};
+
 /**
  * @name ALBUMS
  * @description Array of all albums to display, order matters.
@@ -323,6 +397,7 @@ export const ALBUMS: Album[] = [
 	TokyoSkytreeVistas,
 	Kyoto,
 	TokyoDay,
+	TokyoNight,
 ];
 
 /**

--- a/routes/photos/(_utils)/albums.ts
+++ b/routes/photos/(_utils)/albums.ts
@@ -100,12 +100,97 @@ const TokyoSkytreeVistas: Album = {
 };
 
 /**
+ * Izu Peninsula
+ *
+ * @type {Album}
+ */
+const IzuPeninsula: Album = {
+	name: "The Izu Peninsula",
+	slug: "izu-peninsula",
+	dates: "April 2024",
+	copyrightYear: "2024",
+	photos: [
+		{
+			src: "20240423-3_87A2440-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "izu-lonely-boat",
+		},
+		{
+			src: "20240422-3_87A2153-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "izu-fisherman-edge",
+		},
+		{
+			src: "20240422-3_87A2271-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "izu-shimoda-hotel",
+		},
+		{
+			src: "20240423-3_87A2512-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "izu-crab",
+		},
+		{
+			src: "20240423-3_87A2741-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "izu-cormorant-view",
+		},
+		{
+			src: "20240422-3_87A2291-Pano.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "izu-shirahama-beach-panorama",
+		},
+		{
+			src: "20240422-3_87A2101-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "izu-river-path",
+		},
+		{
+			src: "20240422-3_87A2140-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "izu-suspension-bridge",
+		},
+		{
+			src: "20240423-3_87A2624-Pano.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "izu-heda-port-panorama",
+		},
+		{
+			src: "20240422-3_87A2230-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "izu-rockpool-flowers",
+		},
+		{
+			src: "20240423-3_87A2559-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "izu-yusuge-park-view",
+		},
+		{
+			src: "20240423-3_87A2499-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "izu-busy-fisherman",
+		},
+		{
+			src: "20240423-3_87A2653-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "izu-green-path",
+		},
+		{
+			src: "20240423-3_87A2716-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "izu-sacred-tree",
+		},
+	],
+};
+
+/**
  * @name ALBUMS
  * @description Array of all albums to display, order matters.
  * @type {Album[]}
  * @constant
  */
 export const ALBUMS: Album[] = [
+	IzuPeninsula,
 	TokyoSkytreeVistas,
 ];
 

--- a/routes/photos/(_utils)/albums.ts
+++ b/routes/photos/(_utils)/albums.ts
@@ -254,6 +254,64 @@ const Kyoto: Album = {
 	],
 };
 
+const TokyoDay: Album = {
+	name: "Tokyo Day Vibes",
+	slug: "tokyo-day-vibes",
+	dates: "April 2024",
+	copyrightYear: "2024",
+	photos: [
+		{
+			src: "20240420-3_87A1612-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-station-sketch",
+			noLicense: true,
+		},
+		{
+			src: "20240425-3_87A2833-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-construction",
+		},
+		{
+			src: "20240418-3_87A1508-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-disney-teens",
+			noLicense: true,
+		},
+		{
+			src: "20240425-3_87A2760-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-hamarikyuu-gardens-man",
+		},
+		{
+			src: "20240420-3_87A1697-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-skytree-ueno-park",
+		},
+		{
+			src: "20240425-3_87A2785-Pano.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-hamarikyuu-gardens-pano",
+		},
+		{
+			src: "20240426-3_87A3051-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-kanda-river",
+		},
+		{
+			src: "20240426-3_87A3076-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-walking-sumida",
+			noLicense: true,
+		},
+		{
+			src: "20240408-0_87A9513-Enhanced-NR.jpg",
+			timezone: "Asia/Tokyo",
+			slug: "tokyo-row-blossoms",
+			noLicense: true,
+		},
+	],
+};
+
 /**
  * @name ALBUMS
  * @description Array of all albums to display, order matters.
@@ -264,6 +322,7 @@ export const ALBUMS: Album[] = [
 	IzuPeninsula,
 	TokyoSkytreeVistas,
 	Kyoto,
+	TokyoDay,
 ];
 
 /**

--- a/routes/photos/[album]/[photo].tsx
+++ b/routes/photos/[album]/[photo].tsx
@@ -192,7 +192,11 @@ export default async function PhotoPage(_: Request, ctx: RouteContext) {
 					</div>
 				</a>
 			</section>
-			<License year={date.getUTCFullYear().toString()} />
+			<License
+				year={date.getUTCFullYear().toString()}
+				isPhoto
+				noLicense={photo.noLicense}
+			/>
 		</>
 	);
 }

--- a/routes/photos/[album]/[photo].tsx
+++ b/routes/photos/[album]/[photo].tsx
@@ -111,7 +111,7 @@ export default async function PhotoPage(_: Request, ctx: RouteContext) {
 
 						{/* Default JPEG format (fallback) */}
 						<img
-							class="max-h-full max-w-full rounded-lg"
+							class="max-h-full max-w-full rounded-lg border border-transparent hover:border-stone-300 dark:hover:border-stone-700"
 							src={getImagorUrl(
 								`fit-in/2000x2000/filters:format(avif):quality(80)/${photo.src}`,
 							)}

--- a/routes/photos/[album]/[photo].tsx
+++ b/routes/photos/[album]/[photo].tsx
@@ -97,7 +97,7 @@ export default async function PhotoPage(_: Request, ctx: RouteContext) {
 						<source
 							type="image/avif"
 							srcSet={getImagorUrl(
-								`fit-in/2000x2000/filters:format(avif):quality(100)/${photo.src}`,
+								`fit-in/2000x2000/filters:format(avif):quality(80)/${photo.src}`,
 							)}
 						/>
 
@@ -105,7 +105,7 @@ export default async function PhotoPage(_: Request, ctx: RouteContext) {
 						<source
 							type="image/webp"
 							srcSet={getImagorUrl(
-								`fit-in/2000x2000/filters:format(webp):quality(100)/${photo.src}`,
+								`fit-in/2000x2000/filters:format(webp):quality(80)/${photo.src}`,
 							)}
 						/>
 
@@ -113,7 +113,7 @@ export default async function PhotoPage(_: Request, ctx: RouteContext) {
 						<img
 							class="max-h-full max-w-full rounded-lg"
 							src={getImagorUrl(
-								`fit-in/2000x2000/filters:format(avif):quality(100)/${photo.src}`,
+								`fit-in/2000x2000/filters:format(avif):quality(80)/${photo.src}`,
 							)}
 							alt={photo.src}
 						/>
@@ -168,7 +168,7 @@ export default async function PhotoPage(_: Request, ctx: RouteContext) {
 							<source
 								type="image/avif"
 								srcSet={getImagorUrl(
-									`fit-in/2000x2000/filters:format(avif):quality(100)/${photo.src}`,
+									`fit-in/2000x2000/filters:format(avif):quality(80)/${photo.src}`,
 								)}
 							/>
 
@@ -176,7 +176,7 @@ export default async function PhotoPage(_: Request, ctx: RouteContext) {
 							<source
 								type="image/webp"
 								srcSet={getImagorUrl(
-									`fit-in/2000x2000/filters:format(webp):quality(100)/${photo.src}`,
+									`fit-in/2000x2000/filters:format(webp):quality(80)/${photo.src}`,
 								)}
 							/>
 
@@ -184,7 +184,7 @@ export default async function PhotoPage(_: Request, ctx: RouteContext) {
 							<img
 								class="max-h-full max-w-full rounded-lg"
 								src={getImagorUrl(
-									`fit-in/2000x2000/filters:format(avif):quality(100)/${photo.src}`,
+									`fit-in/2000x2000/filters:format(avif):quality(80)/${photo.src}`,
 								)}
 								alt={photo.src}
 							/>

--- a/routes/photos/[album]/[photo].tsx
+++ b/routes/photos/[album]/[photo].tsx
@@ -111,7 +111,7 @@ export default async function PhotoPage(_: Request, ctx: RouteContext) {
 
 						{/* Default JPEG format (fallback) */}
 						<img
-							class="max-h-full max-w-full rounded-lg border border-transparent hover:border-stone-300 dark:hover:border-stone-700"
+							class="max-h-full max-w-full rounded-lg border-2 border-transparent hover:border-stone-400 dark:hover:border-stone-600"
 							src={getImagorUrl(
 								`fit-in/2000x2000/filters:format(avif):quality(80)/${photo.src}`,
 							)}

--- a/routes/photos/[album]/index.tsx
+++ b/routes/photos/[album]/index.tsx
@@ -11,53 +11,23 @@ const Gallery = ({
 	album: Album;
 }) => {
 	return (
-		<div class="columns-2 md:columns-3 lg:columns-4 gap-4">
+		<div class="columns-2 md:columns-3 gap-4">
 			{album.photos.map((photo, i) => (
 				<a href={`/photos/${album.slug}/${photo.slug}`} class="group">
 					<picture key={i}>
 						{/* AVIF format */}
 						<source
 							type="image/avif"
-							media="(max-width: 767px)"
 							srcSet={getImagorUrl(
-								`fit-in/360x540/filters:format(avif):quality(80)/${photo.src}`,
-							)}
-						/>
-						<source
-							type="image/avif"
-							media="(max-width: 1023px)"
-							srcSet={getImagorUrl(
-								`fit-in/330x495/filters:format(avif):quality(80)/${photo.src}`,
-							)}
-						/>
-						<source
-							type="image/avif"
-							media="(min-width: 1024px)"
-							srcSet={getImagorUrl(
-								`fit-in/300x450/filters:format(avif):quality(80)/${photo.src}`,
+								`fit-in/540x540/filters:format(avif):quality(80)/${photo.src}`,
 							)}
 						/>
 
 						{/* WEBP format */}
 						<source
 							type="image/webp"
-							media="(max-width: 767px)"
 							srcSet={getImagorUrl(
-								`fit-in/360x540/filters:format(webp):quality(80)/${photo.src}`,
-							)}
-						/>
-						<source
-							type="image/webp"
-							media="(max-width: 1023px)"
-							srcSet={getImagorUrl(
-								`fit-in/330x495/filters:format(webp):quality(80)/${photo.src}`,
-							)}
-						/>
-						<source
-							type="image/webp"
-							media="(min-width: 1024px)"
-							srcSet={getImagorUrl(
-								`fit-in/300x450/filters:format(webp):quality(80)/${photo.src}`,
+								`fit-in/540x540/filters:format(webp):quality(80)/${photo.src}`,
 							)}
 						/>
 
@@ -65,7 +35,7 @@ const Gallery = ({
 						<img
 							class="h-auto max-w-full rounded-lg mb-4 hover:shadow-lg border border-transparent hover:border-stone-300 dark:hover:border-stone-700"
 							src={getImagorUrl(
-								`fit-in/360x540/filters:format(avif):quality(80)/${photo.src}`,
+								`fit-in/540x540/filters:format(avif):quality(80)/${photo.src}`,
 							)}
 							alt={photo.src}
 						/>

--- a/routes/photos/[album]/index.tsx
+++ b/routes/photos/[album]/index.tsx
@@ -33,7 +33,7 @@ const Gallery = ({
 
 						{/* Default JPEG format (fallback) */}
 						<img
-							class="h-auto max-w-full rounded-lg mb-4 hover:shadow-lg border border-transparent hover:border-stone-300 dark:hover:border-stone-700"
+							class="h-auto max-w-full rounded-lg mb-4 hover:shadow-lg border-2 border-transparent hover:border-stone-400 dark:hover:border-stone-600"
 							src={getImagorUrl(
 								`fit-in/540x540/filters:format(avif):quality(80)/${photo.src}`,
 							)}

--- a/routes/photos/[album]/index.tsx
+++ b/routes/photos/[album]/index.tsx
@@ -63,7 +63,7 @@ const Gallery = ({
 
 						{/* Default JPEG format (fallback) */}
 						<img
-							class="h-auto max-w-full rounded-lg mb-4 hover:shadow-lg transition-shadow duration-200"
+							class="h-auto max-w-full rounded-lg mb-4 hover:shadow-lg border border-transparent hover:border-stone-300 dark:hover:border-stone-700"
 							src={getImagorUrl(
 								`fit-in/360x540/filters:format(avif):quality(80)/${photo.src}`,
 							)}

--- a/routes/photos/index.tsx
+++ b/routes/photos/index.tsx
@@ -19,7 +19,7 @@ export default function Photos() {
 			</Head>
 			<section>
 				<Breadcrumb />
-				<div class="grid grid-cols-2 lg:grid-cols-3 gap-4">
+				<div class="grid grid-cols-2 md:grid-cols-3 gap-4">
 					{ALBUMS.map((album, i) => (
 						<Album
 							album={album}


### PR DESCRIPTION
Add a number of photo albums to the site

- Izu
- Kyoto
- Tokyo

Changes a number of photo components
- Use `quality(80)` for main photo page to reduce image size
- Add `noLicense` tag to `License` component for photos that should NOT be licensed under `CC BY-SA 4.0`
- Show different license copy on photo vs album pages
- Update styling of photo related components
  - Use blur effect on all albums page
  - Add border to all images